### PR TITLE
bump to 0.6.1

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,8 +20,17 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}   
     - uses: actions/checkout@v3
+    - name: Set up Python "3.10"
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install hansken-extraction-plugin==0.6.1 sentence-transformers
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Build the Docker image    
       run: |
-        docker build -t bert-embeddings .
+        build_plugin bert_embeddings.py . bert-embeddings
         docker tag bert-embeddings ghcr.io/netherlandsforensicinstitute/bert-embeddings:latest
         docker push ghcr.io/netherlandsforensicinstitute/bert-embeddings:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.8
 
 # TODO See API breaking changes in 0.6.0
 # TODO Unpin the SDK
-RUN python -m pip install --no-cache hansken_extraction_plugin==0.5.0 sentence-transformers
+RUN python -m pip install --no-cache hansken_extraction_plugin==0.6.1 sentence-transformers
 
 LABEL maintainer="i.ellis@nfi.nl"
 LABEL hansken.extraction.plugin.image="bert-embeddings"
@@ -13,5 +13,5 @@ EXPOSE 8999
 WORKDIR /app
 RUN python bert_embeddings.py  # run the Python file once to cache the required models
 RUN chmod -R 777 /tmp  # temporary, see why the cache dir can't be written to
-ENTRYPOINT ["/usr/local/bin/serve_plugin"]
+ENTRYPOINT ["/usr/local/bin/serve_plugin", "-vvv"]
 CMD ["bert_embeddings.py", "8999"]

--- a/bert_embeddings.py
+++ b/bert_embeddings.py
@@ -23,7 +23,6 @@ class BERTEmbeddings(MetaExtractionPlugin):
 
     def plugin_info(self):
         plugin_info = PluginInfo(
-            self,
             id=PluginId(domain='nfi.nl', category='media', name='BERT'),
             version='2022.8.25',
             description='BERT embeddings for chatmessages',
@@ -32,7 +31,7 @@ class BERTEmbeddings(MetaExtractionPlugin):
             webpage_url='https://git.eminjenv.nl/-/ide/project/hanskaton/extraction-plugins/bert-embeddings',
             matcher='type=chatMessage',
             license="Apache License 2.0",
-            resources=PluginResources.builder().maximum_cpu(1).maximum_memory(12000).build(),
+            resources=PluginResources(maximum_cpu=1, maximum_memory=12000),
         )
         log.debug(f'returning plugin info: {plugin_info}')
         return plugin_info


### PR DESCRIPTION
* updated used SDK version to 0.6.1
* label plugins during build with the new `build_plugin` script, so that Hansken can efficiently load the plugin (without starting them, so that Hansken can read/get the memory requirements _before_ starting the plugin the first time -- otherwise the first run gets a limited amount of RAM, not the specified amount of RAM)