### PR TITLE
Bump and pin some things to make this plugin runnable with newer versions of Hansken

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,8 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        # Pinning to 0.7.2 is a temporary measure because of an issue with 0.7.3
-        pip install hansken-extraction-plugin==0.7.2 sentence-transformers
+        pip install hansken-extraction-plugin sentence-transformers
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Build and label the Docker image
       run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,9 +27,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install hansken-extraction-plugin sentence-transformers
+        # Pinning to 0.7.2 is a temporary measure because of an issue with 0.7.3
+        pip install hansken-extraction-plugin==0.7.2 sentence-transformers
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Build the Docker image
+    - name: Build and label the Docker image
       run: |
         build_plugin bert_embeddings.py . bert-embeddings
     - name: Release the Docker image on branch main

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM python:3.8
+FROM python:3.10
 
-# TODO See API breaking changes in 0.6.0
-# TODO Unpin the SDK
-RUN python -m pip install --no-cache hansken_extraction_plugin sentence-transformers
+RUN python -m pip install --no-cache hansken_extraction_plugin==0.7.2 sentence-transformers
 
 LABEL maintainer="i.ellis@nfi.nl"
 LABEL hansken.extraction.plugin.image="bert-embeddings"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10
 
-RUN python -m pip install --no-cache hansken_extraction_plugin==0.7.2 sentence-transformers
+RUN python -m pip install --no-cache hansken_extraction_plugin sentence-transformers
 
 LABEL maintainer="i.ellis@nfi.nl"
 LABEL hansken.extraction.plugin.image="bert-embeddings"

--- a/bert_embeddings.py
+++ b/bert_embeddings.py
@@ -24,11 +24,11 @@ class BERTEmbeddings(MetaExtractionPlugin):
     def plugin_info(self):
         plugin_info = PluginInfo(
             id=PluginId(domain='nfi.nl', category='media', name='BERT'),
-            version='2022.12.13',
+            version='2024.3.14',
             description='BERT embeddings for chatmessages',
             author=Author('Isadora Ellis', 'i.ellis@nfi.nl', 'NFI'),
             maturity=MaturityLevel.PROOF_OF_CONCEPT,
-            webpage_url='https://git.eminjenv.nl/-/ide/project/hanskaton/extraction-plugins/bert-embeddings',
+            webpage_url='https://github.com/NetherlandsForensicInstitute/bert-embeddings/',
             matcher='type=chatMessage',
             license="Apache License 2.0",
             resources=PluginResources(maximum_cpu=1, maximum_memory=12000),

--- a/bert_embeddings.py
+++ b/bert_embeddings.py
@@ -53,10 +53,8 @@ class BERTEmbeddings(MetaExtractionPlugin):
                 trace.add_tracelet(to_tracelet(embedding, model_name))
 
 
+# To develop in this plugin
 # if __name__ == "__main__":
 #     run_with_hanskenpy(BERTEmbeddings, endpoint='http://localhost:9091/gatekeeper/',
-#                        # the keystore REST endpoint when this script was exported, note that
-#                        # this can be overridden with --keystore
 #                        keystore='http://localhost:9090/keystore/',
-#                        # the project id of the project named "Semantic search",
 #                        project='326c693c-45bc-4648-b8e3-24abb4f43c1d')


### PR DESCRIPTION
This PR makes the BERT embeddings plugin runnable with current versions of Hansken